### PR TITLE
Add error message for database crash and enable Sentry.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "com.xtreak.notificationdictionary"
         minSdk 24
         targetSdk 31
-        versionCode 9
-        versionName "0.0.9"
+        versionCode 10
+        versionName "0.0.10"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -61,6 +61,7 @@ dependencies {
     implementation'com.huxq17.pump:download:1.3.10'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'de.cketti.library.changelog:ckchangelog:1.2.2'
+    implementation 'io.sentry:sentry-android:4.3.0'
 
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.NotificationDictionary">
+        <meta-data android:name="io.sentry.dsn" android:value="https://c2152c70152f4dbab75dd18714a65699@o996828.ingest.sentry.io/5955342" />
         <activity
             android:name=".AboutActivity"
             android:exported="true"


### PR DESCRIPTION
Pin sentry 4.3.0 due to https://github.com/getsentry/sentry-java/issues/1659 being not resolved.