### PR TITLE
Exclude proper noun result from notification

### DIFF
--- a/app/src/main/java/com/xtreak/notificationdictionary/ProcessTextActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/ProcessTextActivity.kt
@@ -65,7 +65,7 @@ open class ProcessIntentActivity : AppCompatActivity() {
             val dao = database.dictionaryDao()
             var meaning: Word?
             try {
-                meaning = dao.getMeaningsByWord(word, 1)
+                meaning = dao.getVocabularyMeaningsByWord(word, 1)
                 if (meaning != null) {
                     resolveRedirectMeaning(listOf(meaning), dao)
                 }

--- a/app/src/main/java/com/xtreak/notificationdictionary/ProcessTextActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/ProcessTextActivity.kt
@@ -65,7 +65,7 @@ open class ProcessIntentActivity : AppCompatActivity() {
             val dao = database.dictionaryDao()
             var meaning: Word?
             try {
-                meaning = dao.getVocabularyMeaningsByWord(word, 1)
+                meaning = dao.getMeaningsByWord(word, 1)
                 if (meaning != null) {
                     resolveRedirectMeaning(listOf(meaning), dao)
                 }

--- a/app/src/main/java/com/xtreak/notificationdictionary/daos/DictionaryDao.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/daos/DictionaryDao.kt
@@ -18,6 +18,9 @@ interface DictionaryDao {
     @Query("SELECT * FROM dictionary WHERE word = :word COLLATE NOCASE LIMIT :limit")
     fun getMeaningsByWord(word: String, limit: Int): Word?
 
+    @Query("SELECT * FROM dictionary WHERE word = :word AND lexical_category != 'Proper noun' COLLATE NOCASE LIMIT :limit")
+    fun getVocabularyMeaningsByWord(word: String, limit: Int): Word?
+
     @Query("SELECT * FROM dictionary WHERE word = :word COLLATE NOCASE")
     fun getAllMeaningsByWord(word: String): List<Word>
 }

--- a/app/src/main/java/com/xtreak/notificationdictionary/daos/DictionaryDao.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/daos/DictionaryDao.kt
@@ -12,15 +12,15 @@ package com.xtreak.notificationdictionary
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.RewriteQueriesToDropUnusedColumns
 
 @Dao
 interface DictionaryDao {
-    @Query("SELECT * FROM dictionary WHERE word = :word COLLATE NOCASE LIMIT :limit")
+    @RewriteQueriesToDropUnusedColumns
+    @Query("SELECT CASE WHEN lexical_category LIKE 'Proper noun' THEN 2 ELSE 1 END AS priority, * FROM dictionary WHERE word = :word COLLATE NOCASE ORDER BY priority LIMIT :limit")
     fun getMeaningsByWord(word: String, limit: Int): Word?
 
-    @Query("SELECT * FROM dictionary WHERE word = :word AND lexical_category != 'Proper noun' COLLATE NOCASE LIMIT :limit")
-    fun getVocabularyMeaningsByWord(word: String, limit: Int): Word?
-
-    @Query("SELECT * FROM dictionary WHERE word = :word COLLATE NOCASE")
+    @RewriteQueriesToDropUnusedColumns
+    @Query("SELECT CASE WHEN lexical_category LIKE 'Proper noun' THEN 2 ELSE 1 END AS priority, * FROM dictionary WHERE word = :word COLLATE NOCASE ORDER BY priority")
     fun getAllMeaningsByWord(word: String): List<Word>
 }


### PR DESCRIPTION
First of all, thanks for the app, it's great!

I've just noticed a quirk, where it sometimes display a pseudo-meaning for a proper noun match in the notification:
![Screenshot_20240207_133758](https://github.com/tirkarthi/NotificationDictionary/assets/450928/eea66047-e7bb-4045-9ef9-bc9e0e59c6bc)

This quick patch makes a difference:
![Screenshot_20240207_133156](https://github.com/tirkarthi/NotificationDictionary/assets/450928/1a3c56c1-3fa9-4a7c-af39-df0dee0751b9)

Now I understand that it's a potentially breaking change, as it would suddenly stop finding a meaning if the only meaning that exists is a proper noun.

Maybe I could conditionally enable this behavior with a switch?

We'd probably need a dedicated settings page at this point though, which I don't mind providing in another PR if you want