### PR TITLE
Add support to store history and favourite words.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
@@ -68,7 +71,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    def room_version = "2.3.0"
+    def room_version = "2.5.0"
     apply plugin: 'kotlin-kapt'
 
     implementation "androidx.room:room-runtime:$room_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "com.xtreak.notificationdictionary"
         minSdk 24
         targetSdk 33
-        versionCode 22
-        versionName "0.0.22"
+        versionCode 23
+        versionName "0.0.23"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.xtreak.notificationdictionary" >
+    package="com.xtreak.notificationdictionary">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -11,7 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.NotificationDictionary" >
+        android:theme="@style/Theme.NotificationDictionary">
 
         <meta-data
             android:name="io.sentry.dsn"
@@ -22,42 +22,58 @@
             android:exported="true"
             android:label="@string/about"
             android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".HistoryActivity"
+            android:exported="true"
+            android:label="@string/history"
+            android:parentActivityName=".MainActivity" />
+
+        <activity
+            android:name=".FavouriteActivity"
+            android:exported="true"
+            android:label="@string/favourite"
+            android:parentActivityName=".MainActivity"/>
 
         <activity
             android:name=".ProcessTextActivity"
             android:exported="true"
             android:label="@string/process_text_label"
-            android:parentActivityName=".MainActivity" >
+            android:parentActivityName=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.PROCESS_TEXT" />
+
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="text/plain" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
+
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".ProcessViewActivity"
             android:exported="true"
             android:label="@string/process_text_label"
-            android:parentActivityName=".MainActivity" >
+            android:parentActivityName=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".MainActivity"
-            android:exported="true" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/xtreak/notificationdictionary/FavouriteActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/FavouriteActivity.kt
@@ -38,7 +38,7 @@ class FavouriteActivity : AppCompatActivity() {
 
             handler.post {
                 val mRecyclerView = findViewById<RecyclerView>(R.id.favouriteRecyclerView)
-                val mListadapter = HistoryAdapter(entries, this)
+                val mListadapter = HistoryAdapter(entries as MutableList<HistoryDao.WordWithMeaning>, this, true)
                 mRecyclerView.adapter = mListadapter
                 mRecyclerView.layoutManager = linearLayoutManager
                 mListadapter.notifyItemRangeChanged(1, 100)

--- a/app/src/main/java/com/xtreak/notificationdictionary/FavouriteActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/FavouriteActivity.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Karthikeyan Singaravelan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.xtreak.notificationdictionary
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.xtreak.notificationdictionary.adapters.HistoryAdapter
+import java.util.concurrent.Executors
+
+class FavouriteActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_favourite)
+
+        val executor = Executors.newSingleThreadExecutor()
+        val handler = Handler(Looper.getMainLooper())
+
+        val linearLayoutManager = LinearLayoutManager(this)
+        linearLayoutManager.orientation = LinearLayoutManager.VERTICAL
+
+        executor.execute {
+            val database = AppDatabase.getDatabase(this)
+            val historyDao = database.historyDao()
+            var entries = historyDao.getAllFavouriteEntriesWithMeaning()
+
+            handler.post {
+                val mRecyclerView = findViewById<RecyclerView>(R.id.favouriteRecyclerView)
+                val mListadapter = HistoryAdapter(entries, this)
+                mRecyclerView.adapter = mListadapter
+                mRecyclerView.layoutManager = linearLayoutManager
+                mListadapter.notifyItemRangeChanged(1, 100)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/xtreak/notificationdictionary/HistoryActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/HistoryActivity.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Karthikeyan Singaravelan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.xtreak.notificationdictionary
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.xtreak.notificationdictionary.adapters.HistoryAdapter
+import java.util.concurrent.Executors
+
+class HistoryActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_history)
+
+        val executor = Executors.newSingleThreadExecutor()
+        val handler = Handler(Looper.getMainLooper())
+
+        val linearLayoutManager = LinearLayoutManager(this)
+        linearLayoutManager.orientation = LinearLayoutManager.VERTICAL
+
+        executor.execute {
+            val database = AppDatabase.getDatabase(this)
+            val historyDao = database.historyDao()
+            var entries = historyDao.getAllEntriesWithMeaning()
+
+            handler.post {
+                val mRecyclerView = findViewById<RecyclerView>(R.id.historyRecyclerView)
+                val mListadapter = HistoryAdapter(entries, this)
+                mRecyclerView.adapter = mListadapter
+                mRecyclerView.layoutManager = linearLayoutManager
+                mListadapter.notifyItemRangeChanged(1, 100)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/xtreak/notificationdictionary/HistoryActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/HistoryActivity.kt
@@ -38,7 +38,7 @@ class HistoryActivity : AppCompatActivity() {
 
             handler.post {
                 val mRecyclerView = findViewById<RecyclerView>(R.id.historyRecyclerView)
-                val mListadapter = HistoryAdapter(entries, this)
+                val mListadapter = HistoryAdapter(entries as MutableList<HistoryDao.WordWithMeaning>, this, false)
                 mRecyclerView.adapter = mListadapter
                 mRecyclerView.layoutManager = linearLayoutManager
                 mListadapter.notifyItemRangeChanged(1, 100)

--- a/app/src/main/java/com/xtreak/notificationdictionary/MainActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/MainActivity.kt
@@ -145,6 +145,14 @@ class MainActivity : AppCompatActivity() {
                     Word(
                         1,
                         "",
+                        "Store history and favourite words",
+                        1,
+                        1,
+                        """History of searches is stored. Words can also be starred from notification to be stored as favourite. History and Favourite are accessible from the menu at right top."""
+                    ),
+                    Word(
+                        1,
+                        "",
                         "Read meanings aloud as you read",
                         1,
                         1,

--- a/app/src/main/java/com/xtreak/notificationdictionary/MainActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/MainActivity.kt
@@ -148,7 +148,7 @@ class MainActivity : AppCompatActivity() {
                         "Store history and favourite words",
                         1,
                         1,
-                        """History of searches is stored. Words can also be starred from notification to be stored as favourite. History and Favourite are accessible from the menu at right top."""
+                        """History of searches is stored. Words can also be starred from notification to be stored as favourite. History and Favourite are accessible from the menu at right top. In case of issues due to update please uninstall and try reinstalling the app since it needs database changes."""
                     ),
                     Word(
                         1,
@@ -165,14 +165,6 @@ class MainActivity : AppCompatActivity() {
                         1,
                         1,
                         """Click on meaning to copy. Long press to share meaning with others. Notifications also have button for these actions."""
-                    ),
-                    Word(
-                        1,
-                        "",
-                        "Multilingual support",
-                        1,
-                        1,
-                        """Languages supported include French, German and Polish."""
                     ),
                     Word(
                         1,
@@ -446,7 +438,7 @@ class MainActivity : AppCompatActivity() {
         // But we don't want the user to cancel this. It's one time and takes a couple of seconds
 
         // TODO: Make this configurable based on environment?
-        val url = "https://xtreak.sfo3.cdn.digitaloceanspaces.com/dictionaries/dictionary_v2.db.zip"
+        val url = "https://xtreak.sfo3.cdn.digitaloceanspaces.com/dictionaries/v2/$database_name.zip"
         // val url = "http://192.168.0.105:8000/$database_name.zip" // for local mobile testing
         // val url = "http://10.0.2.2:8000/$database_name.zip" // for local emulator testing
 

--- a/app/src/main/java/com/xtreak/notificationdictionary/MainActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/MainActivity.kt
@@ -19,6 +19,7 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.*
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -409,6 +410,14 @@ class MainActivity : AppCompatActivity() {
                     .withLicenseShown(true)
                     .start(this)
             }
+            R.id.history -> {
+                val history_activity = Intent(applicationContext, HistoryActivity::class.java)
+                startActivityForResult(history_activity, 0)
+            }
+            R.id.favourite -> {
+                val favourite_activity = Intent(applicationContext, FavouriteActivity::class.java)
+                startActivityForResult(favourite_activity, 0)
+            }
         }
         return true
     }
@@ -429,7 +438,7 @@ class MainActivity : AppCompatActivity() {
         // But we don't want the user to cancel this. It's one time and takes a couple of seconds
 
         // TODO: Make this configurable based on environment?
-        val url = "https://xtreak.sfo3.cdn.digitaloceanspaces.com/dictionaries/$database_name.zip"
+        val url = "https://xtreak.sfo3.cdn.digitaloceanspaces.com/dictionaries/dictionary_v2.db.zip"
         // val url = "http://192.168.0.105:8000/$database_name.zip" // for local mobile testing
         // val url = "http://10.0.2.2:8000/$database_name.zip" // for local emulator testing
 
@@ -570,12 +579,17 @@ class MainActivity : AppCompatActivity() {
         executor.execute {
             val database = AppDatabase.getDatabase(this)
             val dao = database.dictionaryDao()
+            val historyDao = database.historyDao()
             var meanings: List<Word>
 
             try {
                 meanings = dao.getAllMeaningsByWord(word)
+                if (meanings.isNotEmpty()) {
+                    addHistoryEntry(historyDao, word)
+                }
             } catch (e: Exception) {
                 Sentry.captureException(e)
+                Log.d("ndict:", e.toString())
                 meanings = listOf(
                     Word(
                         1, "", "Error", 1, 1,
@@ -606,6 +620,4 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
-
-
 }

--- a/app/src/main/java/com/xtreak/notificationdictionary/ProcessTextActivity.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/ProcessTextActivity.kt
@@ -54,25 +54,30 @@ open class ProcessIntentActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         val word: String
+        var lexicalCategory: String = ""
         val context = applicationContext
+        val executor = Executors.newSingleThreadExecutor()
+        var definition = "No meaning found"
+
         if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
             word = intent.getCharSequenceExtra(Intent.EXTRA_TEXT).toString().lowercase()
         } else {
             word = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT).toString().lowercase()
         }
 
-        val executor = Executors.newSingleThreadExecutor()
-        var definition = "No meaning found"
 
         // https://stackoverflow.com/questions/1250643/how-to-wait-for-all-threads-to-finish-using-executorservice
         executor.execute {
             val database = AppDatabase.getDatabase(this)
             val dao = database.dictionaryDao()
+            val historyDao = database.historyDao()
+
             var meaning: Word?
             try {
                 meaning = dao.getMeaningsByWord(word, 1)
                 if (meaning != null) {
                     resolveRedirectMeaning(listOf(meaning), dao)
+                    addHistoryEntry(historyDao, word)
                 }
             } catch (e: Exception) {
                 Sentry.captureException(e)
@@ -83,7 +88,13 @@ open class ProcessIntentActivity : AppCompatActivity() {
                             "Please turn on your internet connection and restart the app to download the database."
                 )
             }
-            definition = meaning?.definition ?: "No meaning found"
+            lexicalCategory = meaning?.lexicalCategory ?: ""
+
+            if (meaning?.definition != null) {
+                definition = "${lexicalCategory}, ${meaning?.definition}"
+            } else {
+                definition = "No meaning found"
+            }
         }
         executor.shutdown()
         executor.awaitTermination(10, TimeUnit.SECONDS)
@@ -106,6 +117,7 @@ open class ProcessIntentActivity : AppCompatActivity() {
             addCopyButton(word, definition, context, builder)
             addShareButton(word, definition, context, builder)
             addReadButton(word, definition, context, builder)
+            addFavouriteButton(word, context, builder)
         }
 
         val intent = Intent(
@@ -192,7 +204,6 @@ open class ProcessIntentActivity : AppCompatActivity() {
         context: Context,
         builder: NotificationCompat.Builder
     ) {
-        // Ref : https://stackoverflow.com/questions/14291436/copy-to-clipboard-by-notification-action
         val notificationShare: BroadcastReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent?) {
                 val sharingIntent = Intent(Intent.ACTION_SEND)
@@ -240,7 +251,6 @@ open class ProcessIntentActivity : AppCompatActivity() {
         context: Context,
         builder: NotificationCompat.Builder,
     ) {
-        // Ref : https://stackoverflow.com/questions/14291436/copy-to-clipboard-by-notification-action
         val notificationRead: BroadcastReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent?) {
                 TTSOnInitListener(word, definition, context)
@@ -267,8 +277,52 @@ open class ProcessIntentActivity : AppCompatActivity() {
                 PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
 
-        builder.addAction(NotificationCompat.Action(null, "Read", nRead))
+        // builder.addAction(NotificationCompat.Action(null, "Read", nRead))
     }
+
+    private fun addFavouriteButton(
+        word: String,
+        context: Context,
+        builder: NotificationCompat.Builder
+    ) {
+        val database = AppDatabase.getDatabase(this)
+
+        val notificationFavourite: BroadcastReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent?) {
+                val executor = Executors.newSingleThreadExecutor()
+
+                // unregister the receiver else they will keep adding themselves to context resulting in duplicate calls
+                try {
+                    executor.execute {
+                        val historyDao = database.historyDao()
+                        historyDao.addFavourite(word)
+                    }
+                    context.unregisterReceiver(this)
+                } catch (e: Exception) {
+                    Sentry.captureException(e)
+                    Log.e("ndict", e.toString())
+                    Log.e("Notification Dictionary", "Error in unregistering the receiver")
+                } finally {
+                    executor.shutdown()
+                }
+            }
+        }
+
+        val intentFilter = IntentFilter("com.xtreak.notificationdictionary.ACTION_FAVOURITE")
+        context.registerReceiver(notificationFavourite, intentFilter)
+
+        val star = Intent("com.xtreak.notificationdictionary.ACTION_FAVOURITE")
+        val nStar =
+            PendingIntent.getBroadcast(
+                context,
+                0,
+                star,
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+        builder.addAction(NotificationCompat.Action(null, "Star", nStar))
+    }
+
 
 }
 

--- a/app/src/main/java/com/xtreak/notificationdictionary/Utils.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/Utils.kt
@@ -10,6 +10,9 @@
 
 package com.xtreak.notificationdictionary
 
+import android.util.Log
+import io.sentry.Sentry
+import java.lang.Exception
 import java.util.*
 
 /**
@@ -35,4 +38,33 @@ fun resolveRedirectMeaning(
             }
         }
     }
+}
+
+fun addHistoryEntry(
+    historyDao: HistoryDao,
+    word: String
+) {
+
+    val historyEntry = historyDao.getHistory(word)
+
+    try {
+        if (historyEntry != null) {
+            historyDao.updateHistory(
+                word = word,
+                lastAccessedAt = System.currentTimeMillis()
+            )
+        } else {
+            historyDao.insertHistory(
+                History(
+                    id = null,
+                    word = word,
+                    isFavourite = 0,
+                    lastAccessedAt = System.currentTimeMillis()
+                )
+            )
+        }
+    } catch (e: Exception) {
+        Sentry.captureException(e)
+    }
+
 }

--- a/app/src/main/java/com/xtreak/notificationdictionary/adapters/HistoryAdapter.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/adapters/HistoryAdapter.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Karthikeyan Singaravelan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.xtreak.notificationdictionary.adapters
+
+import android.content.Context
+import android.text.Html
+import android.text.Spanned
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.xtreak.notificationdictionary.History
+import com.xtreak.notificationdictionary.HistoryDao
+import com.xtreak.notificationdictionary.R
+
+
+class HistoryAdapter(data: List<HistoryDao.WordWithMeaning>, context: Context) :
+    RecyclerView.Adapter<HistoryAdapter.ViewHolder>() {
+    private val meaningList: List<HistoryDao.WordWithMeaning> = data
+    private val context: Context = context
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        var lexicalCategory: TextView = itemView.findViewById(R.id.lexicalCategory)
+        var wordMeaning: TextView = itemView.findViewById(R.id.wordMeaning)
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ViewHolder {
+        val view: View = LayoutInflater.from(parent.context)
+            .inflate(R.layout.card_layout, parent, false)
+
+        return ViewHolder(view)
+    }
+
+    private fun formatHtml(content: String): Spanned? {
+        return Html.fromHtml(content, Html.FROM_HTML_MODE_COMPACT)
+    }
+
+    override fun getItemCount(): Int {
+        return meaningList.size
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.lexicalCategory.text = formatHtml("<b> ${meaningList[position].word}")
+        holder.wordMeaning.text = formatHtml("${meaningList[position].definition } <br>")
+    }
+}

--- a/app/src/main/java/com/xtreak/notificationdictionary/adapters/HistoryAdapter.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/adapters/HistoryAdapter.kt
@@ -11,26 +11,39 @@
 package com.xtreak.notificationdictionary.adapters
 
 import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import android.text.Html
 import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
 import android.widget.TextView
+import androidx.core.content.ContextCompat.startActivity
 import androidx.recyclerview.widget.RecyclerView
-import com.xtreak.notificationdictionary.History
+import com.xtreak.notificationdictionary.AppDatabase
 import com.xtreak.notificationdictionary.HistoryDao
+import com.xtreak.notificationdictionary.MainActivity
 import com.xtreak.notificationdictionary.R
+import java.util.concurrent.Executors
 
 
-class HistoryAdapter(data: List<HistoryDao.WordWithMeaning>, context: Context) :
+class HistoryAdapter(
+    data: MutableList<HistoryDao.WordWithMeaning>,
+    context: Context,
+    favourite_page: Boolean
+) :
     RecyclerView.Adapter<HistoryAdapter.ViewHolder>() {
-    private val meaningList: List<HistoryDao.WordWithMeaning> = data
+    private val meaningList: MutableList<HistoryDao.WordWithMeaning> = data
     private val context: Context = context
+    private val favourite_page: Boolean = favourite_page
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        var lexicalCategory: TextView = itemView.findViewById(R.id.lexicalCategory)
-        var wordMeaning: TextView = itemView.findViewById(R.id.wordMeaning)
+        var lexicalCategory: TextView = itemView.findViewById(R.id.lexicalCategoryhistory)
+        var wordMeaning: TextView = itemView.findViewById(R.id.wordMeaninghistory)
+        var deleteEntry: ImageButton = itemView.findViewById(R.id.deleteEntryhistory)
     }
 
     override fun onCreateViewHolder(
@@ -38,7 +51,7 @@ class HistoryAdapter(data: List<HistoryDao.WordWithMeaning>, context: Context) :
         viewType: Int
     ): ViewHolder {
         val view: View = LayoutInflater.from(parent.context)
-            .inflate(R.layout.card_layout, parent, false)
+            .inflate(R.layout.history_layout, parent, false)
 
         return ViewHolder(view)
     }
@@ -52,7 +65,52 @@ class HistoryAdapter(data: List<HistoryDao.WordWithMeaning>, context: Context) :
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.lexicalCategory.text = formatHtml("<b> ${meaningList[position].word}")
-        holder.wordMeaning.text = formatHtml("${meaningList[position].definition } <br>")
+        if (position > meaningList.size) {
+            return
+        }
+
+        val word = meaningList[position].word!!
+        holder.lexicalCategory.text = formatHtml("<b> ${word}")
+        holder.wordMeaning.text = formatHtml("${meaningList[position].definition} <br>")
+
+        val listener = {
+            val intent = Intent(context, MainActivity::class.java)
+            intent.putExtra("NotificationWord", word)
+            startActivity(context, intent, null)
+        }
+
+        holder.wordMeaning.setOnClickListener {
+            listener()
+        }
+
+        holder.lexicalCategory.setOnClickListener {
+            listener()
+        }
+
+        holder.deleteEntry.setOnClickListener {
+            val executor = Executors.newSingleThreadExecutor()
+            val handler = Handler(Looper.getMainLooper())
+
+            executor.execute {
+
+                // Reuse such that if it's history page remove the word and if it's favourite then toggle
+                // favourite column. Maybe refactor this to a method and have a base class to override the
+                // action instead of a toggle here.
+                if (!this.favourite_page) {
+                    val database = AppDatabase.getDatabase(context)
+                    val historyDao = database.historyDao()
+                    historyDao.deleteHistory(word)
+                } else {
+                    val database = AppDatabase.getDatabase(context)
+                    val historyDao = database.historyDao()
+                    historyDao.removeFavourite(word)
+                }
+                meaningList.removeAt(position)
+
+                handler.post {
+                    this.notifyDataSetChanged()
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/xtreak/notificationdictionary/daos/DictionaryDao.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/daos/DictionaryDao.kt
@@ -10,9 +10,7 @@
 
 package com.xtreak.notificationdictionary
 
-import androidx.room.Dao
-import androidx.room.Query
-import androidx.room.RewriteQueriesToDropUnusedColumns
+import androidx.room.*
 
 @Dao
 interface DictionaryDao {

--- a/app/src/main/java/com/xtreak/notificationdictionary/daos/HistoryDao.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/daos/HistoryDao.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Karthikeyan Singaravelan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.xtreak.notificationdictionary
+
+import androidx.room.*
+
+@Dao
+interface HistoryDao {
+    @Query("SELECT * from history where word = :word")
+    fun getHistory(word: String): History?
+
+    @Upsert
+    fun insertHistory(history: History)
+
+    @Query("UPDATE history set last_accessed_at = :lastAccessedAt where word = :word")
+    fun updateHistory(lastAccessedAt: Long, word: String)
+
+    @Query("DELETE from history where word = :word")
+    fun deleteHistory(word: String)
+
+    @Query("SELECT * from history")
+    fun getAllEntries(): List<History>
+
+    @Query("select h.word, h.is_favourite as isFavourite, h.last_accessed_at as lastAccessedAt, d.definition, d.lexical_category as lexicalCategory from history as h join dictionary as d where h.word = d.word group by h.word order by h.last_accessed_at desc;")
+    fun getAllEntriesWithMeaning(): List<WordWithMeaning>
+
+    @Query("select h.word, h.is_favourite as isFavourite, h.last_accessed_at as lastAccessedAt, d.definition, d.lexical_category as lexicalCategory from history as h join dictionary as d where h.word = d.word and h.is_favourite = 1 group by h.word order by h.last_accessed_at desc;")
+    fun getAllFavouriteEntriesWithMeaning(): List<WordWithMeaning>
+
+    @Query("UPDATE history set is_favourite = 1 where word = :word")
+    fun addFavourite(word: String)
+
+    @Query("UPDATE history set is_favourite = 0 where word = :word")
+    fun removeFavourite(word: String)
+
+    @Query("SELECT * from history where is_favourite = 1")
+    fun getFavouriteEntries(): List<History>
+
+    class WordWithMeaning(var isFavourite: Int? = 0, var word: String? = "",
+                          var definition: String? = ""
+    ) {
+        var lastAccessedAt: Int? = 0
+        var lexicalCategory: String? = ""
+    }
+}

--- a/app/src/main/java/com/xtreak/notificationdictionary/entities/Word.kt
+++ b/app/src/main/java/com/xtreak/notificationdictionary/entities/Word.kt
@@ -30,3 +30,13 @@ data class Word(
     @ColumnInfo(name = "definition_no") val definitionNumber: Int?,
     @ColumnInfo(name = "definition") var definition: String?
 )
+
+@Entity(
+    tableName = "history",
+)
+data class History(
+    @PrimaryKey val id: Int?,
+    @ColumnInfo(name = "word") val word: String?,
+    @ColumnInfo(name = "is_favourite") var isFavourite: Int = 0,
+    @ColumnInfo(name = "last_accessed_at") val lastAccessedAt: Long?
+    )

--- a/app/src/main/res/layout/activity_favourite.xml
+++ b/app/src/main/res/layout/activity_favourite.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024, Karthikeyan Singaravelan
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".FavouriteActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/favouriteRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024, Karthikeyan Singaravelan
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".HistoryActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/historyRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/history_layout.xml
+++ b/app/src/main/res/layout/history_layout.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2024, Karthikeyan Singaravelan
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/historyCards"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="15dp"
+    android:checkable="false"
+    android:clickable="false"
+    android:elevation="1dp"
+    android:focusable="false"
+    app:cardBackgroundColor="?meaning_card_background_color"
+    app:cardCornerRadius="5dp"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/lexicalCategoryhistory"
+                android:layout_width="fill_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/lexical_category_background_color"
+                android:paddingLeft="10dp"
+                android:paddingTop="5dp"
+                android:paddingBottom="5dp"
+                android:layout_weight="0.2"
+                android:textColor="?lexical_category_text_color"
+                android:textSize="16sp" />
+
+            <ImageButton
+                android:id="@+id/deleteEntryhistory"
+                android:layout_width="200dp"
+                android:layout_height="40dp"
+                android:layout_weight="0.8"
+                android:background="@android:drawable/ic_menu_delete"
+                />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/wordMeaninghistory"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="10sp"
+            android:paddingLeft="10dp"
+            android:paddingRight="10dp"
+            android:textColor="?meaning_text_color"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -16,4 +16,13 @@
         android:id="@+id/license"
         android:showAsAction="never"
         android:title="@string/license" />
+
+    <item
+        android:id="@+id/history"
+        android:showAsAction="never"
+        android:title="@string/history" />
+    <item
+        android:id="@+id/favourite"
+        android:showAsAction="never"
+        android:title="Favourites" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,7 @@
     <string name="manage">Manage</string>
     <string name="change_confirmation">Do you want to change the language and download database if not present?</string>
     <string name="confirmation">Language</string>
+    <string name="action_settings">Settings</string>
+    <string name="history">History</string>
+    <string name="favourite">Favourites</string>
 </resources>


### PR DESCRIPTION
This PR implements a commonly requested feature to add support to have a list of words searched along with favourite words. The implementation involves a separate table to track the word, is_favourite and last_accessed_at time for sorting the list with recent entries. Whenever there is a word search or a notification lookup the word is recorded. If the same word is seen again then last_accessed_at time is updated. During notification lookup star action currently instead of read for testing toggles is_favourite to be 1 so that favourites page can list them. All favourites are a subset of historical entries. Since the table is stored in respective db the entries are per db and hence when user changes from English to French then the list will be empty. This is due to clicking on the entry from list so that the relevant language is used for lookup. E.g. Having test as a favourite under English and opting to French dictionary to lookup favourite English word doesn't make sense in French since there is no translation feature.

TODO : 

- [ ] HistoryActivity.kt and FavouriteActivity.kt have almost same code except the layout inflation value and the method in dao to fetch all history entries and to fetch favourites respectively. Perhaps this can be refactored.
- [x] Android atleast in Samsung galaxy A54 used for testing seems to only allow 3 actions from notifications. There is already copy, share and read. Perhaps one of them need to be removed.
- [x] Clicking on the history/favourite word in listview should redirect to mainview to search the word.
- [x] Support to delete entry from history page. DAO already has method, Need UI
- [x] Support to unfavourite a word from favourites page. DAO already has method. Need UI.
- [x] Test migrations and upgrade db in CDN for fresh installs to have history table.
- [ ] Test android room 2.5.0 is compatible with fdroid. 