### PR TITLE
Update SDK version as per play store requirements.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,12 +23,12 @@ android {
             storePassword keystoreProperties['storePassword']
         }
     }
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.xtreak.notificationdictionary"
         minSdk 24
-        targetSdk 33
+        targetSdk 34
         versionCode 23
         versionName "0.0.23"
 


### PR DESCRIPTION
> From August 31, 2024, if your target API level is not within 1 year of the latest Android release, you won't be able to update your app.